### PR TITLE
Extra Linebreak After Question Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ subcommands:
 
 ```nsb format path/to/nsb/questions.docx```
 
-It also takes a single optional argument, `--capitalize`. If given, `nsb format` will force every answer line to be capitalized. For example:
+It also takes an optional argument, `--capitalize`. If given, `nsb format` will force every answer line to be capitalized. For example:
 
 ```nsb format path/to/nsb/questions.docx --capitalize```
+
+It also provides a `--line-after-stem` optional argument to add a blank line after the stem in Multiple Choice questions (the official style prior to 2023). For example:
+
+```nsb format path/to/nsb/questions.docx --line-after-stem```
 
 <a name="auto-format"></a>
 ### Auto-Formatting

--- a/nsb_toolbox/cli.py
+++ b/nsb_toolbox/cli.py
@@ -18,9 +18,10 @@ def make(args):
 
 
 def format(args):
-
     questions = RawQuestions.from_docx_path(args.path)
-    questions.format(force_capitalize=args.capitalize)
+    questions.format(
+        force_capitalize=args.capitalize, line_after_stem=args.line_after_stem
+    )
     questions.save(args.path)
 
 
@@ -52,6 +53,11 @@ def main():
         "--capitalize",
         action="store_true",
         help="force all answer lines to be capitalized",
+    )
+    format_parser.add_argument(
+        "--line-after-stem",
+        action="store_true",
+        help="adds a line after the stem in multiple choice questions",
     )
     format_parser.set_defaults(func=format)
 


### PR DESCRIPTION
Fixes #43

Adds a `--line-after-stem` optional argument to `nsb format` to format MC questions in the pre-2023 style.