### PR TITLE
Add error handling for missing subject and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## A command-line utility for formatting Science Bowl questions
 
-Version 0.5.2 - Updated for 2024 NSB
+Version 0.6.1 - Updated for 2026 NSB
 
 The NSB Toolbox contains a set of tools to make it easier to write and edit Science Bowl questions. It ensures that questions are compliant with the official Science Bowl format, allowing writers to focus on just writing the questions. It also highlights common formatting errors for editors, allowing them to focus on checking content without worrying that they're missing formatting issues here and there.
 

--- a/nsb_toolbox/tables.py
+++ b/nsb_toolbox/tables.py
@@ -480,6 +480,14 @@ class TuBCellFormatter(CellFormatter):
 
 
 class SubjectCellFormatter(CellFormatter):
+    def preprocess_format(self, cell: _Cell) -> _Cell:
+        cell = preprocess_cell(cell)
+        if cell.text.strip() == "":
+            highlight_cell_text(cell, WD_COLOR_INDEX.RED)
+            logger.error("Missing subject.")
+            return cell
+        return self.format(cell)
+
     def format(self, cell: _Cell) -> _Cell:
         subject_match = SUBJECT_RE.match(cell.text)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nsb-toolbox"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/rishi-kulkarni/nsbtoolbox"
 description = "Utilities for editing Science Bowl questions"
 authors = ["Rishi Kulkarni <rishi@kulkarni.science>"]

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -223,6 +223,20 @@ class TestFormatSubjectErrors:
         assert test_run.font.highlight_color == WD_COLOR_INDEX.RED
 
 
+class TestFormatSubjectMissing:
+    def test_missing_subject(self, caplog):
+        doc = Document()
+        table = doc.add_table(rows=1, cols=1)
+        cell = table.rows[0].cells[0]
+        cell.text = ""
+
+        formatter = tables.SubjectCellFormatter()
+        result = formatter.preprocess_format(cell)
+
+        assert result.paragraphs[0].runs[0].font.highlight_color == WD_COLOR_INDEX.RED
+        assert "Missing subject." in caplog.text
+
+
 @pytest.fixture
 def format_question_rows():
     test_data = Document(data_dir / "test_question_parser.docx")


### PR DESCRIPTION
Implement error handling for cases where the subject is missing in the `SubjectCellFormatter`. Update the version to 0.6.1 and revise the README to reflect the changes for the 2026 NSB.